### PR TITLE
Update HF_bloodline_events.txt

### DIFF
--- a/Faerun/events/HF_bloodline_events.txt
+++ b/Faerun/events/HF_bloodline_events.txt
@@ -1446,9 +1446,17 @@ character_event = {
 character_event = {
 	id = HF.24021
 	hide_window = yes
-	trigger = {
+	trigger = { 
 		has_dlc = "Holy Fury"
-		has_ambition = obj_forge_bloodline
+		OR = {
+			ROOT = { has_ambition = obj_forge_bloodline }
+			FROM = { has_ambition = obj_forge_bloodline }
+		}
+		any_war = {
+			NOT = {
+				using_cb = auto_invalid_war_cb
+			}
+		}
 	}
 
 	is_triggered_only = yes


### PR DESCRIPTION
Prevented the fake wars from raiding from resetting the forge bloodline ambition 'years at peace' counter. Also, fixed a vanilla bug where the event only fires if the defender has the forge bloodline ambition.