### PR TITLE
Update 52201-52400 Shaaran.txt

### DIFF
--- a/Faerun/history/characters/52201-52400 Shaaran.txt
+++ b/Faerun/history/characters/52201-52400 Shaaran.txt
@@ -2468,6 +2468,9 @@
 	trait = patron_sseth
 	1.1.1 = { birth = yes }
 	31.1.1 = { immortal_age = 30 }
+	1385.7.1 = {
+		remove_trait = absent
+	}
 	1600.1.1 = { death = yes }
 }
 52388 = {


### PR DESCRIPTION
I got an instant game over as Ziss'thiss of Okoth, so I looked into the character history and found that he has the absent trait with no event to remove it.
The event in character history seems to have been accidentally removed when updating Okoth, so I set absent to be removed when he takes over from Pil'it'ith (maybe it should be removed entirely, since he had presumably been living in Sar’Rukoth for quite some time prior to overthrowing Pil’it’ith)